### PR TITLE
Allow list tags

### DIFF
--- a/sds-wp-modal.php
+++ b/sds-wp-modal.php
@@ -129,10 +129,13 @@ function sds_wp_referrer_modal_sanitize( $option ) {
 				'h5' => array(),
 				'h6' => array(),
 				'i' => array(),
+				'li' => array(),
+				'ol' => array(),
 				'p' => array(
 					'class' => array(),
 				),
 				'strong' => array(),
+				'ul' => array(),
 			);
 	return wp_kses( $option, $allowed_html, $allowed_protocols );
 }


### PR DESCRIPTION
These tags, ul, ol, and li, are nice for semantics. I prefer to show the things for visitors from WordPress.org to note in list-form, so this change is nice to see included upstream rather than maintained by my own fork.