### PR TITLE
Remove dependency on jquery, jquery-ui

### DIFF
--- a/modal-referrer.js
+++ b/modal-referrer.js
@@ -1,20 +1,19 @@
-jQuery( document ).ready(function() {
-var ref = document.referrer;
-if (ref.match(/^https?:\/\/([^\/]+\.)?wordpress\.org(\/|$)/i)) {
-  jQuery( function() {
-    jQuery( "#sdsModal").css("display", "block");
-    jQuery( "#sdsModal" ).dialog({
-      modal: true,
-      show: true,
-      width: 'auto',
-      maxWidth: '80%',
-      buttons: {
-        Ok: function() {
-          jQuery( this ).dialog( "close" );
-        }
-      }
-    });
-  } ); 
-} // if ref.match
+window.addEventListener('DOMContentLoaded', function() {
+	const ref = document.referrer;
+	console.log(ref);
+	if (ref.match(/^https?:\/\/(([^\/]+\.)*wordpress\.org|localhost(:\d+))\/.*$/i)) {
+		const tmpl = document.getElementById('sdsModal');
+		const modal = document.importNode(tmpl.content, true);
 
-})
+		const modalElement = modal.firstElementChild;
+		modalElement.id = 'sdsModalImpl';
+
+		const buttons = modal.querySelectorAll('button');
+		for (button of buttons) {
+			button.addEventListener('click', function() {
+				document.getElementById('sdsModalImpl').remove();
+			});
+		}
+		document.body.appendChild(modal);
+	} // if ref.match
+});

--- a/sds-wp-modal.css
+++ b/sds-wp-modal.css
@@ -1,28 +1,30 @@
-#sdsModal {
-   display: none;
+.sdsModal {
+	position: absolute;
+	top: 0;
+	left: 0;
+	right: 0;
+	bottom: 0;
+	background: rgba(100,100,100,0.7);
+	display: flex;
+	align-items: center;
+	justify-content: center;
 }
 .sds-modal-content {
 	background:aliceblue;
-        color: #000;
-        font-size: 14px;
-        padding: 0 .5em 1em .5em;
+	color: #000;
+	font-size: 14px;
+	padding: 0 .5em 1em .5em;
+	max-width: 80%;
 }
 .sds-modal-header  h4.modal-title {
-        font-weight:bold;
-        font-size: 200%;
+	font-weight:bold;
+	font-size: 200%;
 }
 .sds-modal-content .modal-body a {
-    text-decoration: underline;
-    font-weight: bold;
-    color: #666;
+	text-decoration: underline;
+	font-weight: bold;
+	color: #666;
 }
 .sds-modal-content button.btn.btn-default {
-   padding: 1em;
-}
-.ui-dialog {
-   background: aliceblue;
-}
-.ui-widget-overlay {
-   opacity:.6;
-   background: #000;
+	padding: 1em;
 }

--- a/sds-wp-modal.php
+++ b/sds-wp-modal.php
@@ -29,12 +29,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA	02110-1301, USA.
 */
 
 function sds_wp_referrer_modal_enqueue_scripts() {
-	$the_plugin = plugins_url( '', __FILE__ );
-	wp_enqueue_script( 'jquery-ui-core' );
-	wp_enqueue_script( 'jquery-ui-dialog ' );
-	wp_enqueue_script( 'modal-referrer', $the_plugin . '/modal-referrer.js', array( 'jquery', 'jquery-ui-dialog' ) );
-	wp_enqueue_style( 'jquery-ui' , 'https://code.jquery.com/ui/1.12.1/themes/base/jquery-ui.css' );
-	wp_enqueue_style( 'modal-referrer', $the_plugin . '/sds-wp-modal.css', array( 'jquery-ui' ) );
+	wp_enqueue_script( 'modal-referrer', plugins_url( 'modal-referrer.js', __FILE__ ), array(), false, true );
 }
 add_action( 'wp_enqueue_scripts', 'sds_wp_referrer_modal_enqueue_scripts' );
 
@@ -60,21 +55,20 @@ function sds_wp_referrer_modal_filter() {
 	}
 
 ?>
-<div id="sdsModal" class="modal fade" role="dialog">
-<div class="modal-dialog">
-<!-- Modal content-->
-<div class="sds-modal-content">
-<div class="sds-modal-header">
-<h4 class="modal-title"><?php echo stripslashes( $title ); ?></h4>
-</div>
-<div class="modal-body">
-<?php echo stripslashes( $body ); ?>
-</div>
-</div>
-
-</div>
-</div>
-
+<template id="sdsModal">
+	<div class="sdsModal">
+		<link rel="stylesheet" href="<?php echo plugins_url( 'sds-wp-modal.css', __FILE__ ); ?>">
+		<div class="sds-modal-content">
+			<div class="sds-modal-header">
+				<h4 class="modal-title"><?php echo stripslashes( $title ); ?></h4>
+			</div>
+			<div class="modal-body">
+				<?php echo stripslashes( $body ); ?>
+			</div>
+			<button>OK</button>
+		</div>
+	</div>
+</template>
 <?php
 		echo ob_get_clean();
 }
@@ -167,9 +161,9 @@ function sds_wp_referrer_modal_options_page() {
   <p><label for="sds_wp_referrer_modal_title">Title</label><br>
   <input type="text" id="sds_wp_referrer-modal_title" name="sds_wp_referrer_modal_title" value="<?php echo get_option( 'sds_wp_referrer_modal_title' ); ?>" /></p>
 <p> <?php
-   $editor_args = array( 
+   $editor_args = array(
 	'wpautop' => false,
-	); 
+	);
   wp_editor( get_option( 'sds_wp_referrer_modal_body' ), 'sds_wp_referrer_modal_body', $editor_args ); ?> </p>
 	<?php  submit_button(); ?>
   </form>


### PR DESCRIPTION
- Uses HTML <template> tag.
- Adds stylesheet load only when the dialog is actually shown to the user.
- Moves the javascript to the footer.
- Removes dependency on jquery javascript
- Removes dependency on jquery-ui javascript
- Removes dependency on jquery-ui css

Overall this should be almost negligible on the load of a site where previously
the jquery-ui dependency alone caused a large hit on load time through render
blocking.

You might want to tweak the stylesheet more now that we're no-longer using jquery-ui's styles.