### PR TITLE
Refactor for awesome steve

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,38 @@
+language: php
+matrix:
+  include:
+    - php: '7.2'
+      env: PHPC_WPC=1
+    - php: '7.1'
+      env: PHPC_WPC=1
+    - php: '7.0'
+      env: PHPC_WPC=1
+    - php: '5.6'
+      env: PHPC_WPC=1
+    - php: '5.5'
+      env: PHPC_WPC=1
+    - php: '5.4'
+      env: PHPC_WPC=1
+    - php: 5.3
+      dist: precise
+      env: PHPC_WPC=1
+before_script:
+    - pear install pear/PHP_CodeSniffer
+    - export SNIFFS_DIR=/tmp/sniffs
+    - |
+      if [[ "$PHPC_WPC" == "1" ]]; then
+        git clone -b master --depth 1 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git $SNIFFS_DIR
+        git clone -b master --depth 1 https://github.com/wimg/PHPCompatibility.git $SNIFFS_DIR/PHPCompatibility
+        phpenv rehash
+      fi
+script:
+    - find -L . -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l
+    - |
+      if [[ "$PHPC_WPC" == "1" ]]; then
+        phpcs --config-set installed_paths $SNIFFS_DIR/PHPCompatibility
+        phpcs -p -s -v -n . --standard=PHPCompatibility --extensions=php --ignore=*/inc/*
+        phpcs --config-set installed_paths $SNIFFS_DIR
+        phpcs -p -s -v -n . --standard=WordPress-Core --extensions=php --ignore=*/inc/*
+      fi
+notifications:
+    email: false

--- a/sds-wp-modal.css
+++ b/sds-wp-modal.css
@@ -1,5 +1,5 @@
 .sdsModal {
-	position: absolute;
+	position: fixed;
 	top: 0;
 	left: 0;
 	right: 0;
@@ -8,8 +8,9 @@
 	display: flex;
 	align-items: center;
 	justify-content: center;
-        z-index:99;
+	z-index:999999;
 }
+
 .sds-modal-content {
 	background:aliceblue;
 	color: #000;
@@ -17,6 +18,7 @@
 	padding: 0 .5em 1em .5em;
 	max-width: 80%;
 }
+
 .sds-modal-header  h4.modal-title {
 	font-weight:bold;
 	font-size: 200%;
@@ -25,11 +27,13 @@
 	border-bottom-width: 1px;
 	background: #fff;
 }
+
 .sds-modal-content .modal-body a {
 	text-decoration: underline;
 	font-weight: bold;
 	color: #666;
 }
+
 .sds-modal-content button {
 	padding: 1em;
 	background: #888;

--- a/sds-wp-modal.php
+++ b/sds-wp-modal.php
@@ -25,7 +25,7 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA	02110-1301, USA.
 *******************************/
 
-class SDS_WP_Referrer_Modal {
+class WP_Referrer_Modal {
 
 	/**
 	 * WP_Referrer_Modal constructor.

--- a/sds-wp-modal.php
+++ b/sds-wp-modal.php
@@ -1,7 +1,7 @@
-<?php
+<?php // phpcs:ignore
 /**
  * Plugin Name: WP Referrer Modal
- * Plugin URI:	https://github.com/sterndata/wp-referrer-modal
+ * Plugin URI: https://github.com/sterndata/wp-referrer-modal
  * Description: warn about follow homes from wordpress.org
  * Version: 3.2
  * Author: Stern Data Solutions
@@ -9,6 +9,7 @@
  * License: Gnu Public License V2
  * License URI: http://www.gnu.org/licenses/gpl-2.0.html
  */
+
 /************************************
 Copyright (C) 2014-2016 Steven D. Stern dba Stern Data Solutions
 This program is free software; you can redistribute it and/or
@@ -24,150 +25,221 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA	02110-1301, USA.
 *******************************/
 
-/*
-* output all the necessary scripts and css
-*/
+class SDS_WP_Referrer_Modal {
 
-function sds_wp_referrer_modal_enqueue_scripts() {
-	wp_enqueue_script( 'modal-referrer', plugins_url( 'modal-referrer.js', __FILE__ ), array(), false, true );
-}
-add_action( 'wp_enqueue_scripts', 'sds_wp_referrer_modal_enqueue_scripts' );
+	/**
+	 * WP_Referrer_Modal constructor.
+	 *
+	 * @uses WP_Referrer_Modal::init()
+	 *
+	 * @return void
+	 */
 
-/*
- * display the messsages
- *
- * if there' not already set, update the options to use the default modal-message
- */
-
-function sds_wp_referrer_modal_filter() {
-	$title = get_option( 'sds_wp_referrer_modal_title' );
-	$body = get_option( 'sds_wp_referrer_modal_body' );
-	if ( ! $title ) {
-		$title = 'Hello, fellow WordPresser';
-		update_option( 'sds_wp_referrer_modal_title', $title );
+	public function __construct() {
+		$this->init();
 	}
-	if ( ! $body ) {
-		$body = '<p>It seems you came here from a link on WordPress.org.<br>If you are following up on a support question that we were discussing in a forum, please note:</p><p><em>What happens in the forums stays in the forums.</em></p><p><strong>Also be aware that bringing a forum argument here or to any other moderator site is a violation of <a href="https://codex.wordpress.org/Forum_Welcome#The_Bad_Stuff" target=_blank> forum rules</a>.</strong>
-		</p><p>If, on the other hand, you are here to see who I am and what I am up to, read on!</p>';
 
-		update_option( 'sds_wp_referrer_modal_body', $body );
+	/**
+	 * Plugin initialization.
+	 *
+	 * @uses add_filter()
+	 * @uses add_action()
+	 *
+	 * @return void
+	 */
+
+	public function init() {
+
+		add_filter( 'wp_footer', array( $this, 'the_modal' ) );
+		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
+		add_action( 'admin_menu', array( $this, 'create_admin_menu' ) );
+		add_action( 'admin_init', array( $this, 'register_settings' ) );
+
 	}
-$url =  plugins_url( 'sds-wp-modal.css', __FILE__ );
-$e_title = stripslashes( $title ); 
-$e_body = stripslashes( $body );
-$output =  <<<EOF
-<template id="sdsModal">
-	<div class="sdsModal">
-		<link rel="stylesheet" href="$url">
-		<div class="sds-modal-content">
-			<div class="sds-modal-header">
-				<h4 class="modal-title">$e_title</h4>
-			</div>
-			<div class="modal-body">
-				$e_body
-			</div>
-			<button>OK</button>
-		</div>
-	</div>
-</template>
-EOF;
+
+	/**
+	 * Output all the necessary scripts and css.
+	 *
+	 * @uses wp_enqueue_script()
+	 *
+	 * @return void
+	 */
+
+	public function enqueue_scripts() {
+
+		wp_enqueue_script( 'modal-referrer', plugins_url( 'modal-referrer.js', __FILE__ ), array(), false, true );
+
+	}
+
+	/**
+	 * Outputs the modal in the front-end.
+	 *
+	 * @uses
+	 *
+	 * @return string $output HTML of the modal.
+	 */
+
+	public function the_modal() {
+
+		$title = get_option( 'sds_wp_referrer_modal_title' );
+		$body  = get_option( 'sds_wp_referrer_modal_body' );
+		$url   = plugins_url( 'sds-wp-modal.css', __FILE__ );
+
+		if ( empty( $title ) ) {
+
+			$title = 'Hello, fellow WordPresser';
+
+			update_option( 'sds_wp_referrer_modal_title', $title );
+
+		}
+
+		if ( empty( $body ) ) {
+
+			$body = '<p>It seems you came here from a link on WordPress.org.<br>If you are following up on a support question that we were discussing in a forum, please note:</p><p><em>What happens in the forums stays in the forums.</em></p><p><strong>Also be aware that bringing a forum argument here or to any other moderator site is a violation of <a href="https://codex.wordpress.org/Forum_Welcome#The_Bad_Stuff" target=_blank> forum rules</a>.</strong>
+			</p><p>If, on the other hand, you are here to see who I am and what I am up to, read on!</p>';
+
+			update_option( 'sds_wp_referrer_modal_body', $body );
+		}
+
+		$e_title = stripslashes( $title );
+		$e_body  = stripslashes( $body );
+
+		$output = '<template id="sdsModal">
+						<div class="sdsModal">
+							<link rel="stylesheet" href="' . $url . '">
+							<div class="sds-modal-content">
+								<div class="sds-modal-header">
+									<h4 class="modal-title">' . $e_title . '</h4>
+								</div>
+								<div class="modal-body">
+									' . $e_body . '
+								</div>
+								<button>OK</button>
+							</div>
+						</div>
+					</template>';
 		echo $output;
+	}
+
+	/**
+	 * Creates admin menu link
+	 *
+	 * @uses add_options_page()
+	 *
+	 * @return void
+	 */
+
+	public function create_admin_menu() {
+
+		add_options_page(
+			'WP Referrer Modal Settings',
+			'WP Referrer Modal',
+			'manage_options',
+			'sds_wp_referrer_modal',
+			array( $this, 'settings_page' )
+		);
+
+	}
+
+	/**
+	 * Register settings
+	 *
+	 * @uses add_option()
+	 * @uses register_setting()
+	 *
+	 * @return void
+	 */
+
+	public function register_settings() {
+
+		add_option( 'sds_wp_referrer_modal_title', 'Title for the modal' );
+		add_option( 'sds_wp_referrer_modal_body', 'Body for the modal' );
+
+		register_setting(
+			'sds_wp_referrer_modal_options_group',
+			'sds_wp_referrer_modal_title',
+			array( $this, 'text_sanitize' )
+		);
+
+		register_setting(
+			'sds_wp_referrer_modal_options_group',
+			'sds_wp_referrer_modal_body',
+			array( $this, 'html_sanitize' )
+		);
+
+	}
+
+	/**
+	* Sanitize text setting field as needed.
+	*
+	* @param array $input Contains the text string.
+	*
+	* @uses sanitize_text_field()
+	*
+	* @return string $new_input Sanitized text setting.
+	*/
+
+	public function text_sanitize( $input ) {
+
+		if ( isset( $input ) ) {
+			$new_input = sanitize_text_field( $input );
+		}
+
+		return $new_input;
+
+	}
+
+	/**
+	* Sanitize textarea setting field as needed.
+	*
+	* @param array $input Contains the textarea string.
+	*
+	* @uses wp_kses_post()
+	*
+	* @return string $new_input Sanitized textarea string.
+	*/
+
+	public function html_sanitize( $input ) {
+
+		if ( isset( $input ) ) {
+			$new_input = wp_kses_post( $input );
+		}
+
+		return $new_input;
+
+	}
+
+	/**
+	 * Output settings page.
+	 *
+	 * @uses settings_fields()
+	 * @uses get_option()
+	 * @uses wp_editor()
+	 * @uses submit_button()
+	 *
+	 * @return void
+	 */
+
+	public function settings_page() {
+	?>
+		<div class="wrap">
+			<h1>WP Referrer Modal</h1>
+			<form method="post" action="options.php">
+				<?php settings_fields( 'sds_wp_referrer_modal_options_group' ); ?>
+				<p>
+					<h3><?php _e( 'Modal Title' ); ?><h3>
+					<input type="text" id="sds_wp_referrer-modal_title" name="sds_wp_referrer_modal_title" value="<?php echo get_option( 'sds_wp_referrer_modal_title' ); ?>" />
+				</p>
+				<p>
+					<h3><?php _e( 'Modal Body' ); ?><h3>
+					<?php wp_editor( get_option( 'sds_wp_referrer_modal_body' ), 'sds_wp_referrer_modal_body', array( 'wpautop' => false ) ); ?>
+				</p>
+				<?php submit_button(); ?>
+			</form>
+		</div>
+	<?php
+	}
+
 }
-add_filter( 'wp_footer', 'sds_wp_referrer_modal_filter' );
 
-/*
- * autoptimize
-*/
-
-add_filter( 'autoptimize_filter_css_exclude','sds_wp_referrer_modal_ao_override_cssexclude',10,1 );
-function sds_wp_referrer_modal_ao_override_cssexclude( $exclude ) {
-	return $exclude . ',sds-wp-modal.css';
-}
-
-/*
- *  Settings Dialog
- */
-
-function sds_wp_referrer_modal_register_settings() {
-	add_option( 'sds_wp_referrer_modal_title', 'Title for the modal' );
-	add_option( 'sds_wp_referrer_modal_body',  'Body for the modal' );
-	register_setting( 'sds_wp_referrer_modal_options_group', 'sds_wp_referrer_modal_title', 'sds_wp_referrer_modal_sanitize' );
-	register_setting( 'sds_wp_referrer_modal_options_group', 'sds_wp_referrer_modal_body', 'sds_wp_referrer_modal_sanitize' );
-}
- add_action( 'admin_init', 'sds_wp_referrer_modal_register_settings' );
-
-function sds_wp_referrer_modal_register_options_page() {
-	add_options_page( 'WP Referrer Modal Settings', 'WP Referrer Modal', 'manage_options', 'sds_wp_referrer_modal', 'sds_wp_referrer_modal_options_page' );
-}
-add_action( 'admin_menu', 'sds_wp_referrer_modal_register_options_page' );
-
-function sds_wp_referrer_modal_sanitize( $option ) {
-	$allowed_protocols = array(
-		'http',
-		'https',
-		'mailto',
-	);
-	$allowed_html = array(
-			'a' => array(
-					'class' => array(),
-					'href'  => array(),
-					'rel'   => array(),
-					'title' => array(),
-				),
-
-				'b' => array(),
-				'em' => array(),
-				'h1' => array(),
-				'h2' => array(),
-				'h3' => array(),
-				'h4' => array(),
-				'h5' => array(),
-				'h6' => array(),
-				'i' => array(),
-				'li' => array(),
-				'ol' => array(),
-				'p' => array(
-					'class' => array(),
-				),
-				'br' => array(),
-				'strong' => array(),
-				'ul' => array(),
-                                'img' => array(
-					'class' => array(),
-					'src' => array(),
-					'alt' => array(),
-					'title' => array(),
-					'width' => array(),
-					'height' => array(),
-				),
-			);
-	return wp_kses( $option, $allowed_html, $allowed_protocols );
-}
-
-function sds_wp_referrer_modal_add_settings_link( $links ) {
-	$settings_link = '<a href="options-general.php?page=sds_wp_referrer_modal">' . __( 'Settings' ) . '</a>';
-	array_push( $links, $settings_link );
-	  return $links;
-}
-$plugin = plugin_basename( __FILE__ );
-add_filter( "plugin_action_links_$plugin", 'sds_wp_referrer_modal_add_settings_link' );
-
-function sds_wp_referrer_modal_options_page() {
-?>
-  <div>
-  <h2 style="margin-top:1em;">WP Referrer Modal</h2>
-  <form method="post" action="options.php">
-	<?php settings_fields( 'sds_wp_referrer_modal_options_group' ); ?>
-  <h3>Set Title and Body for the modal</h3>
-  <p><label for="sds_wp_referrer_modal_title">Title</label><br>
-  <input type="text" id="sds_wp_referrer-modal_title" name="sds_wp_referrer_modal_title" value="<?php echo get_option( 'sds_wp_referrer_modal_title' ); ?>" /></p>
-<p> <?php
-   $editor_args = array(
-	'wpautop' => false,
-	);
-  wp_editor( get_option( 'sds_wp_referrer_modal_body' ), 'sds_wp_referrer_modal_body', $editor_args ); ?> </p>
-	<?php  submit_button(); ?>
-  </form>
-  </div>
-<?php
-}
+new WP_Referrer_Modal();

--- a/sds-wp-modal.php
+++ b/sds-wp-modal.php
@@ -25,12 +25,12 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA	02110-1301, USA.
 *******************************/
 
-class WP_Referrer_Modal {
+class SDS_WP_MODAL {
 
 	/**
-	 * WP_Referrer_Modal constructor.
+	 * SDS_WP_MODAL constructor.
 	 *
-	 * @uses WP_Referrer_Modal::init()
+	 * @uses SDS_WP_MODAL::init()
 	 *
 	 * @return void
 	 */
@@ -242,4 +242,4 @@ class WP_Referrer_Modal {
 
 }
 
-new WP_Referrer_Modal();
+new SDS_WP_MODAL();


### PR DESCRIPTION
This is the start of a series of PRs that I was thinking to throw towards your sweet referral modal.

This just refactors the code and checks everything with phpcs WordPress-Core coding standards and it also adds a travis.yml for integration with travis-ci, it checks php 5.3 up to 7.2 + WordPress-Core ( everything passes clean for the time being ^_^ ).

The next step is to add more options to style the modal more easily than just fiddling with code all the way :)

I hope you enjoy this and no stress if you're not feeling like merging it ^_^. I know it's a full change and it can be overwhelming but I tried not to mess with your set up much. The only thing I removed for sure was the extra 'settings' call + the autoptimize ignore on the .css, Since you're sharing this there's no point of having a standard ignore on Autoptimize as not everyone is using it :D